### PR TITLE
container: specify python 3.6 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev:
 # Update requirements.txt
 .PHONY: requirements
 requirements:
-	pip-compile --output-file requirements.txt requirements.in
+	pip-compile --output-file requirements.txt requirements.in --upgrade
 
 # Install all packages in requirements.txt
 .PHONY: install-requirements
@@ -29,7 +29,7 @@ install-requirements:
 # Update test-requirements.txt
 .PHONY: test-requirements
 test-requirements:
-	pip-compile --output-file test-requirements.txt test-requirements.in
+	pip-compile --output-file test-requirements.txt test-requirements.in --upgrade
 
 # Install all packages in test-requirements.txt
 .PHONY: install-test-requirements

--- a/container/dev/Dockerfile
+++ b/container/dev/Dockerfile
@@ -1,5 +1,5 @@
 # Use the Python 3 image as our base image
-FROM python:3
+FROM python:3.6
 
 # Copy project directory to /opt/bounce
 ADD . /opt/bounce

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ psycopg2==2.7.4
 sanic==0.7.0
 sqlalchemy==1.2.8
 ujson==1.35               # via sanic
-uvloop==0.9.1             # via sanic
-websockets==4.0.1         # via sanic
+uvloop==0.11.0            # via sanic
+websockets==6.0           # via sanic


### PR DESCRIPTION
Currently, just specifying python:3 pulls in the latest image which is 3.7.
Python 3.7 is newly released and is not yet supported in many libraries and
packages.

:tickets: **Ticket(s)**: Closes #42 #40 

---

## :construction_worker: Changes

_Briefly describe the changes you made and why you made them in bulleted form._
- upgrade dependencies because they are out of date

## :traffic_light: Concerns

_If there is anything you want reviewers to pay special attention to, put it here._

## :mag: Testing Instructions

_Explain how to test your changes, if applicable._
