### PR TITLE
Upgrade requests package

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,3 +6,4 @@ pytest-asyncio==0.8.0
 aiohttp==3.3.2
 idna-ssl==1.1.0
 coveralls==1.3.0
+requests==2.20.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,10 +6,10 @@
 #
 aiohttp==3.3.2
 astroid==1.6.5            # via pylint
-async-timeout==3.0.0      # via aiohttp
-atomicwrites==1.1.5       # via pytest
-attrs==18.1.0             # via aiohttp, pytest
-certifi==2018.8.13        # via requests
+async-timeout==3.0.1      # via aiohttp
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via aiohttp, pytest
+certifi==2018.10.15       # via requests
 chardet==3.0.4            # via aiohttp, requests
 coverage==4.5.1           # via coveralls
 coveralls==1.3.0
@@ -21,17 +21,17 @@ isort==4.3.4
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 more-itertools==4.3.0     # via pytest
-multidict==4.3.1          # via aiohttp, yarl
-pluggy==0.7.1             # via pytest
-py==1.5.4                 # via pytest
+multidict==4.4.2          # via aiohttp, yarl
+pluggy==0.8.0             # via pytest
+py==1.7.0                 # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
 pylint==1.9.1
 pytest-asyncio==0.8.0
-pytest==3.7.2             # via pytest-asyncio
-requests==2.19.1          # via coveralls
+pytest==3.9.3             # via pytest-asyncio
+requests==2.20.0
 six==1.11.0               # via astroid, more-itertools, pylint, pytest
-urllib3==1.23             # via requests
+urllib3==1.24             # via requests
 wrapt==1.10.11            # via astroid
 yapf==0.22.0
 yarl==1.2.6               # via aiohttp


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #

---

## :construction_worker: Changes

Upgrades the `requests` package we depend on for Coveralls to version 2.20.0 to patch a vulnerability.

## :traffic_light: Concerns

Make sure you re-install this dependency next time you pull from master.

## :mag: Testing Instructions

None
